### PR TITLE
Version 1.9

### DIFF
--- a/product-delivery-date-for-woocommerce-lite/includes/prdd-lite-component.php
+++ b/product-delivery-date-for-woocommerce-lite/includes/prdd-lite-component.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'Prdd_Lite_All_Component' ) ) {
 
                 $prdd_lite_get_previous_version = get_option( 'woocommerce_prdd_lite_db_version' );
 
-                $prdd_lite_blog_post_link       = ' https://www.tychesoftwares.com/docs/docs/order-delivery-date-for-woocommerce-lite/usage-tracking/';
+                $prdd_lite_blog_post_link       = 'https://www.tychesoftwares.com/docs/docs/product-delivery-date-for-woocommerce-lite/usage-tracking/';
 
                 $prdd_lite_plugins_page         = '';
                 $prdd_lite_plugin_slug          = '';

--- a/product-delivery-date-for-woocommerce-lite/product-delivery-date-for-woocommerce-lite.php
+++ b/product-delivery-date-for-woocommerce-lite/product-delivery-date-for-woocommerce-lite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Product Delivery Date for WooCommerce - Lite
  * Description: This plugin lets you capture the Delivery Date for each product.
- * Version: 1.8 
+ * Version: 1.9 
  * Author: Tyche Softwares
  * Author URI: https://www.tychesoftwares.com/
  * Requires PHP: 5.6
@@ -17,7 +17,7 @@
 include_once( 'includes/class-prdd-privacy-policy-lite.php' );
 
 global $PrddLiteUpdateChecker;
-$PrddLiteUpdateChecker = '1.8';
+$PrddLiteUpdateChecker = '1.9';
 
 /**
  * This function checks Product delivery date plugin is active or not.
@@ -103,7 +103,7 @@ if ( !class_exists( 'woocommerce_prdd_lite' ) ) {
          * @since 1.0
 		 */
         function prdd_lite_activate() {
-            update_option( 'woocommerce_prdd_lite_db_version', '1.8' );
+            update_option( 'woocommerce_prdd_lite_db_version', '1.9' );
             //Check if installed for the first time.
             add_option( 'prdd_lite_installed', 'yes' );
         }
@@ -118,7 +118,7 @@ if ( !class_exists( 'woocommerce_prdd_lite' ) ) {
         function prdd_lite_update_db_check() {
             $prdd_plugin_version = get_option( 'woocommerce_prdd_lite_db_version' );
             if ( $prdd_plugin_version != $this->get_plugin_version() ) {
-                update_option( 'woocommerce_prdd_lite_db_version', '1.8' );
+                update_option( 'woocommerce_prdd_lite_db_version', '1.9' );
             }
         }
         


### PR DESCRIPTION
Changelog for Product Delivery Date Lite version 1.9

New Feature –

1. A new dismissible notice is added in the WordPress admin, which
provides an option to allow usage tracking of the non-sensitive data of
our plugin from the website.

2. A new link for FAQ list is added to Product Delivery Date meta box
under Add/Edit Product page which lists the top 10 frequently asked
questions. This helps you to resolve your queries in a more faster way
if they are already been answered or you can simply contact our Support
team with the contact details provided.
3. A Welcome page is added which will be shown on installation or
updating of the plugin. It explains some exciting features of Lite
version and PRO version as well.

4. A survey is added on deactivation of the plugin which helps us to
know why is plugin is being or not used. This helps in improvising the
plugin functionalities.

Bug Fixes:

1. Some strings of the Product Delivery Date LITE plugin were not being
translated. Now, we have updated the .pot and .po files. So, strings of
the plugin can be translated.

2. Icon for the Delivery Date on the product page were not coming in the
Delivery Date field. This issue has been fixed now.

3. Scripting error was coming on the product page. This issue has been
fixed now.