### PR TITLE
Fix #84:fixed the first day of calendar for preview theme

### DIFF
--- a/product-delivery-date-for-woocommerce-lite/includes/admin/prdd-lite-delivery-settings.php
+++ b/product-delivery-date-for-woocommerce-lite/includes/admin/prdd-lite-delivery-settings.php
@@ -157,6 +157,7 @@ class prdd_lite_delivery_settings {
                 jQuery( "#prdd_lite_calendar_day" ).change( function() {
                     jQuery( "#prdd_lite_new_switcher" ).datepicker( "option","firstDay", jQuery(this).val() );
                 });
+                jQuery( "#prdd_lite_new_switcher" ).datepicker( "option","firstDay", '. $first_day .' );
                 jQuery( ".ui-datepicker-inline" ).css( "font-size","1.4em" );
             });
         });


### PR DESCRIPTION
THe first day of calendar for the preview theme was not updating as per the setting