### PR TITLE
Version 2.1.1

### DIFF
--- a/product-delivery-date-for-woocommerce-lite/includes/prdd-lite-component.php
+++ b/product-delivery-date-for-woocommerce-lite/includes/prdd-lite-component.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Prdd_Lite_All_Component' ) ) {
 
 			if ( true === $is_admin ) {
 
-				require_once 'component/WooCommerce-Check/ts-woo-active.php';
+				require_once 'component/woocommerce-check/ts-woo-active.php';
 
 				require_once 'component/tracking-data/ts-tracking.php';
 				require_once 'component/deactivate-survey-popup/class-ts-deactivation.php';

--- a/product-delivery-date-for-woocommerce-lite/product-delivery-date-for-woocommerce-lite.php
+++ b/product-delivery-date-for-woocommerce-lite/product-delivery-date-for-woocommerce-lite.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Product Delivery Date for WooCommerce - Lite
  * Description: This plugin lets you capture the Delivery Date for each product.
- * Version: 2.1
+ * Version: 2.1.1
  * Author: Tyche Softwares
  * Author URI: https://www.tychesoftwares.com/
  * Requires PHP: 5.6

--- a/product-delivery-date-for-woocommerce-lite/readme.txt
+++ b/product-delivery-date-for-woocommerce-lite/readme.txt
@@ -167,6 +167,9 @@ You can refer **[here](https://www.tychesoftwares.com/differences-pro-lite-versi
 6. WooCommerce -> Orders - edit an existing order page.
 
 == Changelog ==
+= 2.1.1 (17.09.2019) =
+* Fixed an error displayed on the View Deliveries page.
+
 = 2.1 (17.09.2019) = 
 * Made the plugin compliant with WPCS standards.
 


### PR DESCRIPTION
The SVN & git copies do not match. The case used for woocommerce-check
folder is incorrect, which is resulting in an error in v2.1.

Rectified it to be in sync.