### PR TITLE
_prdd_lite_date meta key was coming on the edit order page.

### DIFF
--- a/class-prdd-lite-woocommerce.php
+++ b/class-prdd-lite-woocommerce.php
@@ -528,6 +528,7 @@ if ( ! class_exists( 'Prdd_Lite_Woocommerce' ) ) {
 									$_prdd_lite_date = $item->get_meta( '_prdd_lite_date' );
 									if ( $_prdd_lite_date ) {
 										wc_add_order_item_meta( $item_id, '_prdd_date', $_prdd_lite_date );
+										wc_delete_order_item_meta( $item_id, '_prdd_lite_date', $_prdd_lite_date );
 									}
 								}
 							}


### PR DESCRIPTION
_prdd_lite_date meta key was coming on the edit order page. This is fixed now.
Fixes #140